### PR TITLE
Fix: Correct `build-args` Usage in release.yml Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/flask-api:${{ steps.version.outputs.version_tag }}
             ghcr.io/${{ github.repository_owner }}/flask-api:latest
-        build-args: # Ensure this is correctly indented and structured
-          TAG: ${{ steps.version.outputs.version_tag }}
+          build-args: |
+            TAG=${{ steps.version.outputs.version_tag }}
 
       - name: Build and push Streamlit UI Docker image
         uses: docker/build-push-action@v5
@@ -83,8 +83,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/streamlit-ui:${{ steps.version.outputs.version_tag }}
             ghcr.io/${{ github.repository_owner }}/streamlit-ui:latest
-        build-args: # Ensure this is correctly indented and structured
-          TAG: ${{ steps.version.outputs.version_tag }}
+          build-args: |
+            TAG=${{ steps.version.outputs.version_tag }}
 
       - name: Test Docker images
         run: |


### PR DESCRIPTION
This PR corrects the usage of `build-args` in the `.github/workflows/release.yml` workflow file. The changes are made to ensure proper passing of build arguments to Docker builds for the Flask API and Streamlit UI Docker images.

#### Key Changes:
- **Corrected `build-args` Syntax:** Updated the `build-args` specification to use a newline-separated string format within the `with` field.
  - For the Flask API Docker image, `build-args` is now correctly formatted as:
    ```yaml
    build-args: |
      TAG=${{ steps.version.outputs.version_tag }}
    ```
  - For the Streamlit UI Docker image, `build-args` is now correctly formatted as:
    ```yaml
    build-args: |
      TAG=${{ steps.version.outputs.version_tag }}
    ```

These corrections ensure that the Docker images are built with the appropriate tags, as specified by the semantic versioning step. The adjustments resolve the "Unexpected value 'build-args'" error and maintain the workflow's integrity.