### PR TITLE
Fix: Update Dockerfile Paths in release.yml Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./hubitat_lock_manager/Dockerfile.api
+          file: Dockerfile.api
           tags: |
             ghcr.io/${{ github.repository_owner }}/flask-api:${{ steps.version.outputs.version_tag }}
             ghcr.io/${{ github.repository_owner }}/flask-api:latest
@@ -80,7 +80,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./hubitat_lock_manager/Dockerfile.ui
+          file: Dockerfile.ui
           tags: |
             ghcr.io/${{ github.repository_owner }}/streamlit-ui:${{ steps.version.outputs.version_tag }}
             ghcr.io/${{ github.repository_owner }}/streamlit-ui:latest


### PR DESCRIPTION
This PR corrects the paths to the Dockerfiles in the `.github/workflows/release.yml` workflow file for building and pushing Docker images.

#### Key Changes:
- **Updated Dockerfile Paths:**  
  - Changed `file` path from `./hubitat_lock_manager/Dockerfile.api` to `Dockerfile.api` for the Flask API Docker image.
  - Changed `file` path from `./hubitat_lock_manager/Dockerfile.ui` to `Dockerfile.ui` for the Streamlit UI Docker image.

These changes ensure that the workflow correctly locates and uses the appropriate Dockerfiles for building the respective Docker images. This update resolves potential build failures due to incorrect file paths.