### PR TITLE
Fix Docker build error due to missing `curl`

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -8,7 +8,7 @@ ARG TAG
 WORKDIR /app
 
 # Download and extract the repository zip at the specific tag
-RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y curl unzip && rm -rf /var/lib/apt/lists/* \
     && curl -L -o repo.zip https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${TAG}.zip \
     && unzip repo.zip \
     && mv $(ls -d */ | head -n 1)/* . \


### PR DESCRIPTION
This PR addresses a failure in the Docker build process of the Flask API due to the `curl` command not being found. The issue arose because the base Docker image used for building the API did not have `curl` installed, which is required to download files from URLs.

The following changes have been made to resolve the issue:

- Modified `Dockerfile.api`: Added the installation of `curl` during the image build process by adding it to the existing `apt-get install` command. This ensures that `curl` is available when the script attempts to download the repository.
- Cleanup: Removed the temporary package list cache after installing `curl` and `unzip` to minimize the Docker image size.

This fix should allow the Docker build to complete successfully and resolve the workflow error.