### PR TITLE
Switch Docker image registry from GitHub Container Registry to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Flask API Docker image
         uses: docker/build-push-action@v5
@@ -72,13 +71,14 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/hubitat-lock-manager-api:${{ steps.version.outputs.version_tag }}
-            ghcr.io/${{ github.repository_owner }}/hubitat-lock-manager-api:latest
+            syncsoftco/hubitat-lock-manager-api:${{ steps.version.outputs.version_tag }}
+            syncsoftco/hubitat-lock-manager-api:latest
           build-args: |
             TAG=${{ steps.version.outputs.version_tag }}
             GITHUB_REPOSITORY=${{ github.repository }}
             APP_MODULE="hubitat_lock_manager.api"
             APP_PORT=5000
+
       - name: Build and push Streamlit UI Docker image
         uses: docker/build-push-action@v5
         with:
@@ -86,9 +86,9 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/hubitat-lock-manager-ui:${{ steps.version.outputs.version_tag }}
-            ghcr.io/${{ github.repository_owner }}/hubitat-lock-manager-ui:latest
-          build-args: |
+            syncsoftco/hubitat-lock-manager-ui:${{ steps.version.outputs.version_tag }}
+            syncsoftco/hubitat-lock-manager-ui:latest
+          build_args: |
             TAG=${{ steps.version.outputs.version_tag }}
             GITHUB_REPOSITORY=${{ github.repository }}
             APP_MODULE="hubitat_lock_manager.ui"


### PR DESCRIPTION
This pull request modifies the release workflow to push Docker images to Docker Hub instead of GitHub Container Registry. The main changes include:

- **Login:** The workflow now logs in to Docker Hub using the provided `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets.
- **Image tags:** The image tags have been updated to use the `syncsoftco` namespace on Docker Hub.
- **Build arguments:** The build arguments remain mostly unchanged, except for the removal of the `GITHUB_REPOSITORY` argument which is no longer needed. 

This change allows for easier management and distribution of the Docker images through Docker Hub. 
