### PR TITLE
Remove `APP_PORT` configuration and streamline Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
             TAG=${{ steps.version.outputs.version_tag }}
             GITHUB_REPOSITORY=${{ github.repository }}
             APP_MODULE="hubitat_lock_manager.api"
-            APP_PORT=5000
 
       - name: Build and push Streamlit UI Docker image
         uses: docker/build-push-action@v5
@@ -92,4 +91,3 @@ jobs:
             TAG=${{ steps.version.outputs.version_tag }}
             GITHUB_REPOSITORY=${{ github.repository }}
             APP_MODULE="hubitat_lock_manager.ui_launcher"
-            APP_PORT=5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,12 @@ RUN apt-get update && apt-get install -y git
 ARG GITHUB_REPOSITORY
 ARG TAG
 ARG APP_MODULE
-ARG APP_PORT
 
 # Construct the repository URL
 ARG REPO_PATH=https://github.com/${GITHUB_REPOSITORY}.git
 
 # Install necessary Python dependencies
 RUN pip install git+${REPO_PATH}@${TAG}
-
-# Expose the port the app runs on
-EXPOSE ${APP_PORT}
 
 # Use the shell form of CMD to evaluate APP_MODULE
 CMD python -m ${APP_MODULE}


### PR DESCRIPTION
This PR makes two key changes:

1. **Removes `APP_PORT`**: The `APP_PORT` argument is no longer used in the GitHub Actions workflow and has been removed from the `Dockerfile`. This suggests that the application's port configuration is now handled differently, possibly through environment variables or dynamic assignment at runtime.

2. **Simplifies `Dockerfile`**: The `EXPOSE` instruction, which was previously used to declare the exposed port, has been removed from the `Dockerfile`. This aligns with the removal of `APP_PORT` and streamlines the Docker image build process.