### PR TITLE
Add Base Dockerfile for Hubitat Lock Manager Project

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,17 @@
+# Use the official Python image from the Docker Hub
+FROM python:3.9-slim
+
+# Install git and any other necessary dependencies
+RUN apt-get update && apt-get install -y git
+
+# Define build arguments
+ARG GITHUB_REPOSITORY
+ARG TAG
+
+# Construct the repository URL
+ARG REPO_PATH=https://github.com/${GITHUB_REPOSITORY}.git
+
+# Install necessary Python dependencies
+RUN pip install git+${REPO_PATH}@${TAG}
+
+# This base Dockerfile doesn't specify CMD, so it can be extended in child Dockerfiles


### PR DESCRIPTION
This pull request introduces a new `Dockerfile.base` to the repository. The base Dockerfile is designed to serve as a foundational image that can be extended in other Dockerfiles within the project. Key features include:
- **Python 3.9 Slim Base Image:** Utilizes the lightweight Python 3.9 slim image from Docker Hub.
- **Dependency Installation:** Installs `git` and any necessary Python dependencies directly from the GitHub repository.
- **Build Arguments:** Supports dynamic repository paths and tags through build arguments, allowing for flexible builds.
- **Extensibility:** This base Dockerfile does not include a CMD directive, making it easy to extend in child Dockerfiles tailored to specific components of the project.

This addition simplifies the management of Docker images by providing a consistent and reusable base configuration.