### PR TITLE
Add Base Docker Image Build Step to Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Build and push the base Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            syncsoftco/hubitat-lock-manager:${{ steps.version.outputs.version_tag }}
+            syncsoftco/hubitat-lock-manager:latest
+          build-args: |
+            GITHUB_REPOSITORY=${{ github.repository }}
+            TAG=${{ steps.version.outputs.version_tag }}
+
       - name: Build and push Flask API Docker image
         uses: docker/build-push-action@v5
         with:
@@ -74,8 +87,8 @@ jobs:
             syncsoftco/hubitat-lock-manager-api:${{ steps.version.outputs.version_tag }}
             syncsoftco/hubitat-lock-manager-api:latest
           build-args: |
-            TAG=${{ steps.version.outputs.version_tag }}
             GITHUB_REPOSITORY=${{ github.repository }}
+            TAG=${{ steps.version.outputs.version_tag }}
             APP_MODULE="hubitat_lock_manager.api"
 
       - name: Build and push Streamlit UI Docker image
@@ -88,6 +101,6 @@ jobs:
             syncsoftco/hubitat-lock-manager-ui:${{ steps.version.outputs.version_tag }}
             syncsoftco/hubitat-lock-manager-ui:latest
           build-args: |
-            TAG=${{ steps.version.outputs.version_tag }}
             GITHUB_REPOSITORY=${{ github.repository }}
+            TAG=${{ steps.version.outputs.version_tag }}
             APP_MODULE="hubitat_lock_manager.ui_launcher"


### PR DESCRIPTION
This pull request enhances the existing `release.yml` GitHub Actions workflow by adding a new step to build and push the base Docker image. Key updates include:

- **Base Docker Image Build:** A new step has been added to build and push the base Docker image using the `Dockerfile.base`. The image is tagged with both the version tag and `latest`.
- **Build Arguments:** The base image build step includes build arguments for `GITHUB_REPOSITORY` and `TAG`, ensuring the correct repository and version are used.
- **Consistency Improvements:** The existing Flask API and Streamlit UI Docker image build steps have been adjusted for consistency, specifically with the order and inclusion of build arguments.

This change streamlines the workflow by incorporating the base image build process, enabling more modular and efficient Docker image management across the project.