### PR TITLE
Refactor Docker Build Process for Modular Components in `hubitat-lock-manager`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,7 @@ jobs:
             syncsoftco/hubitat-lock-manager-api:${{ steps.version.outputs.version_tag }}
             syncsoftco/hubitat-lock-manager-api:latest
           build-args: |
-            GITHUB_REPOSITORY=${{ github.repository }}
             TAG=${{ steps.version.outputs.version_tag }}
-            APP_MODULE="hubitat_lock_manager.api"
 
       - name: Build and push Streamlit UI Docker image
         uses: docker/build-push-action@v5
@@ -101,6 +99,4 @@ jobs:
             syncsoftco/hubitat-lock-manager-ui:${{ steps.version.outputs.version_tag }}
             syncsoftco/hubitat-lock-manager-ui:latest
           build-args: |
-            GITHUB_REPOSITORY=${{ github.repository }}
             TAG=${{ steps.version.outputs.version_tag }}
-            APP_MODULE="hubitat_lock_manager.ui_launcher"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.base
           push: true
           tags: |
             syncsoftco/hubitat-lock-manager:${{ steps.version.outputs.version_tag }}
@@ -81,7 +81,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.api
           push: true
           tags: |
             syncsoftco/hubitat-lock-manager-api:${{ steps.version.outputs.version_tag }}
@@ -95,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.ui
           push: true
           tags: |
             syncsoftco/hubitat-lock-manager-ui:${{ steps.version.outputs.version_tag }}

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,8 +1,8 @@
 # Define build argument for the base image tag
-ARG BASE_TAG=latest
+ARG TAG=latest
 
 # Extend from the dynamically tagged base Dockerfile
-FROM syncsoftco/hubitat-lock-manager:${BASE_TAG}
+FROM syncsoftco/hubitat-lock-manager:${TAG}
 
 # Use the shell form of CMD to launch the executable
 CMD python -m hubitat_lock_manager.api

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,8 @@
+# Define build argument for the base image tag
+ARG BASE_TAG=latest
+
+# Extend from the dynamically tagged base Dockerfile
+FROM syncsoftco/hubitat-lock-manager:${BASE_TAG}
+
+# Use the shell form of CMD to launch the executable
+CMD python -m hubitat_lock_manager.api

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,8 @@
+# Define build argument for the base image tag
+ARG BASE_TAG=latest
+
+# Extend from the dynamically tagged base Dockerfile
+FROM syncsoftco/hubitat-lock-manager:${BASE_TAG}
+
+# Use the shell form of CMD to launch the executable
+CMD python -m hubitat_lock_manager.ui_launcher

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -2,7 +2,7 @@
 ARG TAG=latest
 
 # Extend from the dynamically tagged base Dockerfile
-FROM syncsoftco/hubitat-lock-manager:${BASE_TAG}
+FROM syncsoftco/hubitat-lock-manager:${TAG}
 
 # Use the shell form of CMD to launch the executable
 CMD python -m hubitat_lock_manager.ui_launcher

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,5 +1,5 @@
 # Define build argument for the base image tag
-ARG BASE_TAG=latest
+ARG TAG=latest
 
 # Extend from the dynamically tagged base Dockerfile
 FROM syncsoftco/hubitat-lock-manager:${BASE_TAG}


### PR DESCRIPTION
This PR refactors the Docker build process in the `hubitat-lock-manager` repository to support modular components, aligning each Docker image with a specific part of the application. The changes include:

1. **Workflow Adjustments:**
   - The GitHub Actions workflow (`release.yml`) has been updated to use specific Dockerfiles for different components of the application:
     - `Dockerfile.base` for the base image.
     - `Dockerfile.api` for the API service.
     - `Dockerfile.ui` for the Streamlit UI.

2. **New Dockerfiles:**
   - Added `Dockerfile.api` for building the API service image, extending from the base image with a dynamically tagged version.
   - Added `Dockerfile.ui` for building the Streamlit UI image, also extending from the base image.

3. **Removed Unnecessary Build Arguments:**
   - The workflow no longer passes the `GITHUB_REPOSITORY` or `APP_MODULE` build arguments, streamlining the build process.

These changes allow for more modular and maintainable Docker images, enabling independent updates and deployments of the API and UI components.