### PR TITLE
Switch to Using Dockerfile.base for Base Image Build in Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.base
           push: true
           tags: |
             syncsoftco/hubitat-lock-manager:${{ steps.version.outputs.version_tag }}


### PR DESCRIPTION
This pull request updates the `release.yml` GitHub Actions workflow to use the newly introduced `Dockerfile.base` for building the base Docker image. Key changes include:

- **File Path Update:** The base Docker image build step now references `Dockerfile.base` instead of the default `Dockerfile`, ensuring that the correct base image is built and pushed.
- **Consistent Tagging:** The base Docker image continues to be tagged with both the version tag and `latest`, maintaining consistency with the project's Docker image tagging strategy.

This change optimizes the workflow by explicitly using the `Dockerfile.base` for building the base image, aligning with the modular Dockerfile structure introduced in the repository.