### PR TITLE
Refactor `list_key_codes` Error Handling and Add OS Module Import

### DIFF
--- a/hubitat_lock_manager/api.py
+++ b/hubitat_lock_manager/api.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 from flask import Flask, request, jsonify
+import os
 
 from hubitat_lock_manager import controller
 
@@ -50,13 +51,7 @@ def list_devices():
 def list_key_codes():
     device_id = request.args.get("device_id", type=int)
     if not device_id:
-        return (jsonify({"error": "device_id is required"}),)
-    #
-    # device_ids = frozenset(
-    #     [device.id for device in smart_lock_controller.list_devices().devices]
-    # )
-    # if device_id not in device_ids:
-    #     return jsonify({"error": f"device_id {device_id} not found"}), 400
+        raise ValueError("device_id is required")
 
     try:
         result = smart_lock_controller.list_key_codes(device_id)


### PR DESCRIPTION
This pull request introduces the following changes:

- **Error Handling Improvement**: The `list_key_codes` endpoint in `api.py` has been refactored to raise a `ValueError` when `device_id` is missing, instead of returning a JSON response with an error message. This change improves the clarity and consistency of error handling in the codebase.
  
- **OS Module Import**: The `os` module has been imported at the top of `api.py`. Although not immediately used in the provided diff, this addition could facilitate future enhancements, such as handling environment variables or file operations.

This PR aims to streamline error handling and prepare the codebase for potential upcoming features that might require the `os` module.