### PR TITLE
Fix Streamlit Module Execution in `ui_launcher.py`

### DIFF
--- a/hubitat_lock_manager/ui_launcher.py
+++ b/hubitat_lock_manager/ui_launcher.py
@@ -4,8 +4,8 @@ import subprocess
 # Read the port from an environment variable
 port = os.getenv("PORT", "8501")  # Default port is 8501 if not specified
 
-# Construct the command to run the Streamlit script with the specified port
-command = ["streamlit", "run", "ui.py", "--server.port", port]
+# Construct the command to run the Streamlit module with the specified port
+command = ["python", "-m", "streamlit", "run", "hubitat_lock_manager.ui", "--server.port", port]
 
 # Run the command
 subprocess.run(command)


### PR DESCRIPTION
This pull request addresses an issue in `ui_launcher.py` where the Streamlit script was not being executed correctly. The change ensures proper execution of the Streamlit module using the `python -m streamlit run` command. Additionally, the target script path is updated to `hubitat_lock_manager.ui` for improved clarity.

**Key changes:**

* **Corrected Streamlit execution:** The command to run Streamlit is modified to use `python -m streamlit run` instead of the previous incorrect approach.
* **Updated script path:** The path to the Streamlit script is updated to `hubitat_lock_manager.ui` to accurately reflect its location within the module.

This fix ensures that the Hubitat Lock Manager UI launches correctly, providing a seamless user experience. 
