### PR TITLE
Make `--api-url` a Required Argument in `ui.py`

### DIFF
--- a/hubitat_lock_manager/ui.py
+++ b/hubitat_lock_manager/ui.py
@@ -151,7 +151,7 @@ def main(api_url):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the Smart Lock Management Streamlit app.")
-    parser.add_argument("--api-url", type=str, default="http://127.0.0.1:5000", help="URL of the Flask API")
+    parser.add_argument("--api-url", type=str, required=True, help="URL of the Flask API")
     args = parser.parse_args()
 
     main(args.api_url)


### PR DESCRIPTION
- Updated `ui.py` to remove the default value for the `--api-url` argument.
- The `--api-url` argument is now a required parameter, ensuring the URL of the Flask API must be explicitly provided when running the Smart Lock Management Streamlit app.
- This change enforces explicit configuration and prevents accidental usage of a default API URL, promoting better control over the environment in which the application is executed.