### PR TITLE
Add environment variable support for API URL in Hubitat Lock Manager UI launcher

### DIFF
--- a/hubitat_lock_manager/ui_launcher.py
+++ b/hubitat_lock_manager/ui_launcher.py
@@ -6,6 +6,9 @@ import sys
 # Read the port from an environment variable
 port = os.getenv("PORT", "8501")  # Default port is 8501 if not specified
 
+# Read the API URL from the environment variable
+api_url = os.getenv("HLM_API_URL", "http://127.0.0.1:5000")  # Default API URL
+
 # Determine the file path for the Streamlit app
 module_name = "hubitat_lock_manager.ui"
 spec = importlib.util.find_spec(module_name)
@@ -17,8 +20,12 @@ if spec is None:
 # Get the absolute path of the .py file
 file_path = spec.origin
 
-# Construct the command to run the Streamlit script with the specified port
-command = ["streamlit", "run", file_path, "--server.port", port]
+# Construct the command to run the Streamlit script with the specified port and API URL
+command = [
+    "streamlit", "run", file_path,
+    "--server.port", port,
+    "--", "--api-url", api_url
+]
 
 # Run the command
 subprocess.run(command)


### PR DESCRIPTION
This PR introduces the ability to configure the API URL used by the Hubitat Lock Manager UI via an environment variable (`HLM_API_URL`). This allows for greater flexibility in deployment scenarios where the UI and API might be running on different hosts or ports.

**Key changes:**

* The `ui_launcher.py` script now reads the `HLM_API_URL` environment variable, defaulting to `http://127.0.0.1:5000` if not set.
* The API URL is passed to the Streamlit app as a command-line argument (`--api-url`).
* The Streamlit app can now use this configured API URL to interact with the backend API.

**Benefits:**

* Easier configuration of the UI to connect to the API in various deployment environments.
* Improved decoupling between the UI and API components.

This change should not impact existing setups where the default API URL is sufficient. Users can now leverage the `HLM_API_URL` environment variable to customize the API endpoint as needed. 
