### PR TITLE
Remove Exception Handling for HTTP and URL Errors in `rest_client.py`

### DIFF
--- a/hubitat_lock_manager/rest_client.py
+++ b/hubitat_lock_manager/rest_client.py
@@ -22,13 +22,8 @@ class CloudRunRestClient:
 
         req.add_header("Authorization", f"Bearer {self._get_id_token()}")
 
-        try:
-            with urllib.request.urlopen(req) as response:
-                return response.read().decode('utf-8')
-        except urllib.error.HTTPError as e:
-            return f"HTTP Error: {e.code} - {e.reason}"
-        except urllib.error.URLError as e:
-            return f"URL Error: {e.reason}"
+        with urllib.request.urlopen(req) as response:
+            return response.read().decode('utf-8')
 
     def get(self, resource):
         return self._make_request('GET', resource)

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -92,36 +92,6 @@ class TestCloudRunRestClient(unittest.TestCase):
         self.assertEqual(req.get_method(), "DELETE")
         self.assertEqual(response, json.dumps(self.data))
 
-    @patch("google.oauth2.id_token.fetch_id_token", return_value="test_token")
-    @patch("urllib.request.urlopen")
-    def test_http_error_handling(self, mock_urlopen, mock_fetch_id_token):
-        # Arrange
-        mock_urlopen.side_effect = urllib.error.HTTPError(
-            url=self.base_url,
-            code=404,
-            msg="Not Found",
-            hdrs=None,
-            fp=None,
-        )
-
-        # Act
-        response = self.client.get(self.resource)
-
-        # Assert
-        self.assertEqual(response, "HTTP Error: 404 - Not Found")
-
-    @patch("google.oauth2.id_token.fetch_id_token", return_value="test_token")
-    @patch("urllib.request.urlopen")
-    def test_url_error_handling(self, mock_urlopen, mock_fetch_id_token):
-        # Arrange
-        mock_urlopen.side_effect = urllib.error.URLError("No internet connection")
-
-        # Act
-        response = self.client.get(self.resource)
-
-        # Assert
-        self.assertEqual(response, "URL Error: No internet connection")
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request removes the custom exception handling for HTTP and URL errors in the `rest_client.py` module. The changes include:

- Removed the `try-except` block that handled `urllib.error.HTTPError` and `urllib.error.URLError` in the `_make_request` method.
- Simplified the `_make_request` method to allow exceptions to propagate naturally, providing better visibility into errors during runtime.
- Deleted the corresponding test cases in `test_rest_client.py` that were specifically designed to test the removed error handling logic.

This change is aimed at improving error transparency and leveraging the calling code or higher-level exception handling strategies to manage these errors.