### PR TITLE
Upgrade pip and Install Python Dependencies in Base Dockerfile

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,6 +12,7 @@ ARG TAG
 ARG REPO_PATH=https://github.com/${GITHUB_REPOSITORY}.git
 
 # Install necessary Python dependencies
+RUN pip install --upgrade pip
 RUN pip install git+${REPO_PATH}@${TAG}
 
 # This base Dockerfile doesn't specify CMD, so it can be extended in child Dockerfiles


### PR DESCRIPTION
This PR enhances the `Dockerfile.base` by adding a step to upgrade `pip` before installing Python dependencies. The following changes were made:

- Added a command to upgrade `pip` to the latest version using `pip install --upgrade pip`.
- Ensured that Python dependencies are installed using the latest version of `pip` for better compatibility and security.
- The `RUN pip install git+${REPO_PATH}@${TAG}` command remains unchanged for installing the repository dependencies.

These improvements ensure that the Docker image uses the most up-to-date version of `pip`, reducing the risk of encountering issues with dependency management.