### PR TITLE
Enhance Error Handling in `list_devices` Endpoint

### DIFF
--- a/hubitat_lock_manager/api.py
+++ b/hubitat_lock_manager/api.py
@@ -43,8 +43,15 @@ def list_devices():
     try:
         result = smart_lock_controller.list_devices()
         return jsonify(dataclasses.asdict(result)), 200
+    except ValueError as e:
+        logging.error(f"ValueError: {str(e)}")
+        return jsonify({"error": "Invalid request data"}), 400
+    except KeyError as e:
+        logging.error(f"KeyError: {str(e)}")
+        return jsonify({"error": "Missing data"}), 400
     except Exception as e:
-        return jsonify({"error": str(e)}), 400
+        logging.error(f"Unhandled Exception: {str(e)}")
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @app.route("/list_key_codes", methods=["GET"])


### PR DESCRIPTION
This pull request improves the error handling in the `list_devices` endpoint of the Hubitat Lock Manager API. Specifically, it addresses the following:

1. **Specific Exception Handling**:
   - Added specific exception handling for `ValueError` and `KeyError` with corresponding error messages and HTTP status codes (`400 Bad Request`).
   - Log the details of these exceptions for better debugging.

2. **General Exception Handling**:
   - Improved general exception handling to log unhandled exceptions and return a `500 Internal Server Error` response, providing a more user-friendly error message.

These enhancements will make error responses more descriptive and informative, aiding in easier troubleshooting and providing clearer feedback to API users.