### PR TITLE
Make Hubitat IP Configuration Environment-Driven

### DIFF
--- a/hubitat_lock_manager/api.py
+++ b/hubitat_lock_manager/api.py
@@ -5,7 +5,7 @@ import os
 
 from hubitat_lock_manager import controller
 
-HUB_IP = "192.168.86.37"
+HUB_IP = os.getenv("HUB_IP", "192.168.86.37")
 
 app = Flask(__name__)
 smart_lock_controller = controller.create_smart_lock_controller(HUB_IP)


### PR DESCRIPTION
This pull request updates the Hubitat Lock Manager's `api.py` to configure the Hubitat IP address via an environment variable. Previously hardcoded, the IP address is now fetched from the `HUB_IP` environment variable, with a fallback to `"192.168.86.37"` if the variable is not set.

Key changes include:

- Replaced the hardcoded `HUB_IP` value with `os.getenv("HUB_IP", "192.168.86.37")` to allow dynamic configuration via environment variables.
- This update makes the configuration more flexible and suitable for different environments without modifying the source code.

These changes improve the adaptability of the application by leveraging environment variables for configuration management.