### PR TITLE
Add Tailscale Installation and Conditional Startup via `api_launcher.py`

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,5 +4,8 @@ ARG TAG=latest
 # Extend from the dynamically tagged base Dockerfile
 FROM syncsoftco/hubitat-lock-manager:${TAG}
 
-# Use the shell form of CMD to launch the executable
-CMD python -m hubitat_lock_manager.api
+# Install Tailscale during build time
+RUN apt-get update && apt-get install -y tailscale
+
+# Launch the executable
+CMD python -m hubitat_lock_manager.api_launcher

--- a/hubitat_lock_manager/api_launcher.py
+++ b/hubitat_lock_manager/api_launcher.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+import sys
+
+def start_tailscale(auth_key):
+    print("Starting Tailscale...")
+
+    # Authenticate and start Tailscale
+    subprocess.run(["tailscale", "up", "--authkey", auth_key], check=True)
+
+    print("Tailscale started successfully.")
+
+def main():
+    # Check if TAILSCALE_AUTHKEY is set in the environment
+    auth_key = os.getenv("TAILSCALE_AUTHKEY")
+    
+    if auth_key:
+        start_tailscale(auth_key)
+    else:
+        print("TAILSCALE_AUTHKEY is not set, skipping Tailscale startup.")
+
+    # Start the Hubitat Lock Manager API
+    subprocess.run([sys.executable, "-m", "hubitat_lock_manager.api"], check=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces several enhancements to the Hubitat Lock Manager Docker setup:

- **Tailscale Installation at Build Time**:
  - Updated the Dockerfile (`Dockerfile.api`) to install Tailscale during the image build process using `apt-get`.
  - This change ensures that Tailscale is always available in the container, reducing the startup time and making the container more predictable.

- **Introduction of `api_launcher.py`**:
  - Added a new Python script, `api_launcher.py`, which conditionally starts Tailscale based on the presence of the `TAILSCALE_AUTHKEY` environment variable.
  - If `TAILSCALE_AUTHKEY` is set, the script will start Tailscale with the provided authentication key before launching the Hubitat Lock Manager API.
  - If `TAILSCALE_AUTHKEY` is not set, Tailscale startup is skipped, and the API is launched directly.

- **CMD Update**:
  - The Dockerfile `CMD` directive has been updated to run `api_launcher.py` instead of directly invoking the API. This allows the script to handle the Tailscale startup logic.

These changes streamline the container initialization process and improve flexibility by allowing Tailscale to be started conditionally based on environment variables, enhancing the overall deployment process.