### PR TITLE
Update Dockerfile to Install Tailscale from Official Repository

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -5,7 +5,13 @@ ARG TAG=latest
 FROM syncsoftco/hubitat-lock-manager:${TAG}
 
 # Install Tailscale during build time
-RUN apt-get update && apt-get install -y tailscale
+RUN apt-get update && \
+    apt-get install -y curl gnupg2 && \
+    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null && \
+    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.list | tee /etc/apt/sources.list.d/tailscale.list >/dev/null && \
+    apt-get update && \
+    apt-get install -y tailscale && \
+    rm -rf /var/lib/apt/lists/*
 
 # Launch the executable
 CMD python -m hubitat_lock_manager.api_launcher


### PR DESCRIPTION
This PR updates the Dockerfile to install Tailscale using the official repository for improved security and stability. The installation process includes adding the Tailscale GPG key and repository to the sources list, followed by cleaning up the apt cache to reduce the image size.