### PR TITLE
Update Dockerfile.api to Use ENTRYPOINT Instead of CMD

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -13,5 +13,5 @@ RUN apt-get update && \
     apt-get install -y tailscale && \
     rm -rf /var/lib/apt/lists/*
 
-# Launch the executable
-CMD python -m hubitat_lock_manager.api_launcher
+# Set the ENTRYPOINT to launch the Python script
+ENTRYPOINT ["python", "-m", "hubitat_lock_manager.api_launcher"]


### PR DESCRIPTION
This PR updates the `Dockerfile.api` to replace the `CMD` directive with `ENTRYPOINT`. This change ensures that the container runs the `hubitat_lock_manager.api_launcher` script as its primary process, allowing for better control over how the container is executed, particularly with regard to passing additional command-line arguments.