### PR TITLE
Update Dockerfile.ui to Use ENTRYPOINT Instead of CMD

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -4,5 +4,5 @@ ARG TAG=latest
 # Extend from the dynamically tagged base Dockerfile
 FROM syncsoftco/hubitat-lock-manager:${TAG}
 
-# Use the shell form of CMD to launch the executable
-CMD python -m hubitat_lock_manager.ui_launcher
+# Set the ENTRYPOINT to launch the Python script
+ENTRYPOINT ["python", "-m", "hubitat_lock_manager.ui_launcher"]


### PR DESCRIPTION
This PR modifies the `Dockerfile.ui` to replace the `CMD` directive with `ENTRYPOINT`. This change ensures that the container runs the `hubitat_lock_manager.ui_launcher` script as its primary process, providing more control over command-line arguments if needed.