### PR TITLE
Correct Tailscale Keyring Installation in Dockerfile

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,7 +7,7 @@ FROM syncsoftco/hubitat-lock-manager:${TAG}
 # Install Tailscale during build time
 RUN apt-get update && \
     apt-get install -y curl gnupg2 && \
-    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null && \
+    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.gpg | gpg --dearmor -o /usr/share/keyrings/tailscale-archive-keyring.gpg && \
     curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.list | tee /etc/apt/sources.list.d/tailscale.list >/dev/null && \
     apt-get update && \
     apt-get install -y tailscale && \


### PR DESCRIPTION
This PR fixes the Tailscale keyring installation process by ensuring the GPG key is properly de-armored and saved to the correct location during the Docker build process.