### PR TITLE
Simplify Tailscale Installation in Dockerfile

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,11 +7,7 @@ FROM syncsoftco/hubitat-lock-manager:${TAG}
 # Install Tailscale during build time
 RUN apt-get update && \
     apt-get install -y curl gnupg2 && \
-    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.gpg | gpg --dearmor -o /usr/share/keyrings/tailscale-archive-keyring.gpg && \
-    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.list | tee /etc/apt/sources.list.d/tailscale.list >/dev/null && \
-    apt-get update && \
-    apt-get install -y tailscale && \
-    rm -rf /var/lib/apt/lists/*
+    curl -fsSL https://tailscale.com/install.sh | sh
 
 # Set the ENTRYPOINT to launch the Python script
 ENTRYPOINT ["python", "-m", "hubitat_lock_manager.api_launcher"]


### PR DESCRIPTION
This PR updates the Dockerfile to simplify the Tailscale installation process by replacing the manual keyring and source list setup with a single command using the Tailscale installation script.