### PR TITLE
Add Support for Starting `tailscaled` Daemon Before Tailscale Authentication

### DIFF
--- a/hubitat_lock_manager/api_launcher.py
+++ b/hubitat_lock_manager/api_launcher.py
@@ -2,16 +2,16 @@ import os
 import subprocess
 import sys
 
-def start_tailscaled():
-    print("Starting tailscaled...")
-    subprocess.run(["tailscaled", "--state", "/var/lib/tailscale/tailscaled.state"], check=True)
-    print("tailscaled started successfully.")
-
 def start_tailscale(auth_key):
     print("Starting Tailscale...")
     # Authenticate and start Tailscale
     subprocess.run(["tailscale", "up", "--authkey", auth_key], check=True)
     print("Tailscale started successfully.")
+
+def start_tailscaled():
+    print("Starting tailscaled...")
+    subprocess.run(["tailscaled", "--state", "/var/lib/tailscale/tailscaled.state"], check=True)
+    print("tailscaled started successfully.")
 
 def main():
     # Check if TAILSCALE_AUTHKEY is set in the environment

--- a/hubitat_lock_manager/api_launcher.py
+++ b/hubitat_lock_manager/api_launcher.py
@@ -2,19 +2,25 @@ import os
 import subprocess
 import sys
 
+def start_tailscaled():
+    print("Starting tailscaled...")
+    subprocess.run(["tailscaled", "--state", "/var/lib/tailscale/tailscaled.state"], check=True)
+    print("tailscaled started successfully.")
+
 def start_tailscale(auth_key):
     print("Starting Tailscale...")
-
-    # Authenticate and start Tailscale
     subprocess.run(["tailscale", "up", "--authkey", auth_key], check=True)
-
     print("Tailscale started successfully.")
 
 def main():
     # Check if TAILSCALE_AUTHKEY is set in the environment
     auth_key = os.getenv("TAILSCALE_AUTHKEY")
-    
+
     if auth_key:
+        # Start the Tailscale daemon
+        start_tailscaled()
+        
+        # Connect to tailnet
         start_tailscale(auth_key)
     else:
         print("TAILSCALE_AUTHKEY is not set, skipping Tailscale startup.")

--- a/hubitat_lock_manager/api_launcher.py
+++ b/hubitat_lock_manager/api_launcher.py
@@ -9,6 +9,7 @@ def start_tailscaled():
 
 def start_tailscale(auth_key):
     print("Starting Tailscale...")
+    # Authenticate and start Tailscale
     subprocess.run(["tailscale", "up", "--authkey", auth_key], check=True)
     print("Tailscale started successfully.")
 


### PR DESCRIPTION
This PR enhances the Tailscale integration by adding support for starting the `tailscaled` daemon before authenticating and connecting to the Tailnet. The following changes have been made:

- Added a new function `start_tailscaled()` to initiate the `tailscaled` daemon with the specified state file.
- Modified the `main()` function to start `tailscaled` before authenticating with the Tailscale network.
- The script now ensures that `tailscaled` is running before attempting to bring up Tailscale with the provided authentication key.
- Minor formatting improvements for better readability.

These changes help ensure that the Tailscale daemon is properly started and managed within the script, improving the reliability of the connection process.