### PR TITLE
Install Golang and Update Dependencies in Dockerfile

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,5 +4,8 @@ ARG TAG=latest
 # Extend from the dynamically tagged base Dockerfile
 FROM syncsoftco/hubitat-lock-manager:${TAG}
 
+# Install golang and any other necessary dependencies
+RUN apt-get update && apt-get install -y golang
+
 # Set the ENTRYPOINT to run the standalone binary
 ENTRYPOINT ["python", "-m", "hubitat_lock_manager.api"]


### PR DESCRIPTION
This PR updates the `Dockerfile.api` to install Golang and any other necessary dependencies. Additionally, it maintains the ENTRYPOINT for running the Python `hubitat_lock_manager.api` module.