### PR TITLE
Update CLI entry point and repository URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     description="A library to manage smart locks within the Hubitat ecosystem",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/hubitat_lock_manager",
+    url="https://github.com/syncsoftco/HubitatLockManager",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "hubitat-lock-manager=hubitat_lock_manager.main:main",
+            "hubitat-lock-manager=hubitat_lock_manager.cli:main",
         ],
     },
     author="pseudonymous",


### PR DESCRIPTION
This PR updates the `setup.py` to change the console script entry point from `main` to `cli` for the `hubitat-lock-manager`. Additionally, it updates the repository URL to point to the correct GitHub location: `https://github.com/syncsoftco/HubitatLockManager`.