### PR TITLE
Add go.mod with module dependencies for HubitatLockManager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/syncsoftco/HubitatLockManager
+
+go 1.19
+
+require (
+    github.com/gorilla/mux v1.8.0
+    tailscale.com v1.44.0
+)


### PR DESCRIPTION
Initialized `go.mod` for the project, specifying Go 1.19 as the version and including dependencies for Gorilla Mux and Tailscale.