### PR TITLE
Migrate Docker API from Python to Go and Update Dockerfile

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,5 +7,20 @@ FROM syncsoftco/hubitat-lock-manager:${TAG}
 # Install golang and any other necessary dependencies
 RUN apt-get update && apt-get install -y golang
 
-# Set the ENTRYPOINT to run the standalone binary
-ENTRYPOINT ["python", "-m", "hubitat_lock_manager.api"]
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy go.mod and go.sum for dependency management
+COPY go.mod go.sum ./
+
+# Download Go module dependencies (caches dependencies)
+RUN go mod download
+
+# Copy the source code from the hubitat_lock_manager directory
+COPY hubitat_lock_manager/api.go ./hubitat_lock_manager/
+
+# Build the Go API
+RUN go build -o /go-api ./hubitat_lock_manager/api.go
+
+# Set the ENTRYPOINT to run the Go API binary
+ENTRYPOINT ["/go-api"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -10,17 +10,17 @@ RUN apt-get update && apt-get install -y golang
 # Set the working directory inside the container
 WORKDIR /app
 
-# Copy go.mod and go.sum for dependency management
+# Copy go.mod and go.sum for dependency management (copies them to /app)
 COPY go.mod go.sum ./
 
-# Download Go module dependencies (caches dependencies)
+# Download Go module dependencies (caches dependencies in /app)
 RUN go mod download
 
-# Copy the source code from the hubitat_lock_manager directory
+# Copy the source code from the hubitat_lock_manager directory to /app/hubitat_lock_manager
 COPY hubitat_lock_manager/api.go ./hubitat_lock_manager/
 
-# Build the Go API
-RUN go build -o /go-api ./hubitat_lock_manager/api.go
+# Build the Go API (output binary in /app)
+RUN go build -o go-api ./hubitat_lock_manager/api.go
 
-# Set the ENTRYPOINT to run the Go API binary
-ENTRYPOINT ["/go-api"]
+# Set the ENTRYPOINT to run the Go API binary (use relative path)
+ENTRYPOINT ["./go-api"]


### PR DESCRIPTION
- Replaced the Python API with a Go API in `Dockerfile.api`.
- Set the working directory to `/app` inside the Docker container.
- Added steps to manage Go module dependencies by copying `go.mod` and `go.sum` and running `go mod download`.
- Updated the build process to compile the Go API binary (`go-api`) from the source file `hubitat_lock_manager/api.go`.
- Modified the `ENTRYPOINT` to execute the Go API binary instead of the previous Python module.

This change transitions the Dockerfile from running a Python-based API to a Go-based API, improving performance and aligning with the project’s new Go-based backend.