### PR TITLE
Update api.go

### DIFF
--- a/hubitat_lock_manager/api.go
+++ b/hubitat_lock_manager/api.go
@@ -116,7 +116,14 @@ func main() {
     r.HandleFunc("/list_devices", ListDevices).Methods("GET")
     r.HandleFunc("/list_key_codes", ListKeyCodes).Methods("GET")
 
+    // Get the port from the environment variable or use 5000 as the default
+    port := os.Getenv("PORT")
+    if port == "" {
+        port = "5000"
+    }
+
     // Start the server
-    log.Println("Starting server on port 5000...")
-    log.Fatal(http.ListenAndServe(":5000", r))
+    log.Printf("Starting server on port %s...\n", port)
+    log.Fatal(http.ListenAndServe(":"+port, r))
 }
+


### PR DESCRIPTION
This PR updates the API server to dynamically select the port from the `PORT` environment variable, defaulting to port 5000 if not set. This is particularly useful for Cloud Run deployments where the port is provided via the environment.