### PR TITLE
Update package to main for Go API and tests

### DIFF
--- a/hubitat_lock_manager/api.go
+++ b/hubitat_lock_manager/api.go
@@ -1,4 +1,4 @@
-package hubitat_lock_manager
+package main
 
 import (
     "encoding/json"

--- a/hubitat_lock_manager/api_test.go
+++ b/hubitat_lock_manager/api_test.go
@@ -1,4 +1,4 @@
-package hubitat_lock_manager
+package main
 
 import (
     "bytes"


### PR DESCRIPTION
Refactored `api.go` and `api_test.go` to use the `main` package, aligning with the executable nature of the Go application. This change prepares the code for proper compilation and execution as a standalone binary.