### PR TITLE
Update CLI Command Path for Hubitat Lock Manager API

### DIFF
--- a/hubitat_lock_manager/api.go
+++ b/hubitat_lock_manager/api.go
@@ -41,7 +41,7 @@ func CreateKeyCode(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    args := []string{"-m", "hubitat_lock_manager.main", "--hub-ip", hubIP, "--action", "create", "--username", req.Username, "--code", req.Code}
+    args := []string{"-m", "hubitat_lock_manager.cli", "--hub-ip", hubIP, "--action", "create", "--username", req.Username, "--code", req.Code}
     if req.DeviceID != 0 {
         args = append(args, "--device-id", fmt.Sprint(req.DeviceID))
     }
@@ -66,7 +66,7 @@ func DeleteKeyCode(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    args := []string{"-m", "hubitat_lock_manager.main", "--hub-ip", hubIP, "--action", "delete", "--username", req.Username}
+    args := []string{"-m", "hubitat_lock_manager.cli", "--hub-ip", hubIP, "--action", "delete", "--username", req.Username}
     if req.DeviceID != 0 {
         args = append(args, "--device-id", fmt.Sprint(req.DeviceID))
     }
@@ -84,7 +84,7 @@ func DeleteKeyCode(w http.ResponseWriter, r *http.Request) {
 
 // ListDevices lists all devices
 func ListDevices(w http.ResponseWriter, r *http.Request) {
-    args := []string{"-m", "hubitat_lock_manager.main", "--hub-ip", hubIP, "--action", "list_devices"}
+    args := []string{"-m", "hubitat_lock_manager.cli", "--hub-ip", hubIP, "--action", "list_devices"}
 
     output, err := executeCommand(args...)
     if err != nil {
@@ -106,7 +106,7 @@ func ListKeyCodes(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    args := []string{"-m", "hubitat_lock_manager.main", "--hub-ip", hubIP, "--action", "list", "--device-id", deviceID}
+    args := []string{"-m", "hubitat_lock_manager.cli", "--hub-ip", hubIP, "--action", "list", "--device-id", deviceID}
 
     output, err := executeCommand(args...)
     if err != nil {


### PR DESCRIPTION
This PR modifies the Hubitat Lock Manager API to reflect the updated path of the CLI command from `hubitat_lock_manager.main` to `hubitat_lock_manager.cli`. The changes ensure that the API correctly interfaces with the revised CLI structure.

### Key Changes:
1. **Command Path Update**:
   - Changed all occurrences of `hubitat_lock_manager.main` to `hubitat_lock_manager.cli` to match the new CLI module path.

2. **Affected API Endpoints**:
   - `/create_key_code`: Updated the command to use the new CLI path for creating key codes.
   - `/delete_key_code`: Updated the command to use the new CLI path for deleting key codes.
   - `/list_devices`: Updated the command to use the new CLI path for listing devices.
   - `/list_key_codes`: Updated the command to use the new CLI path for listing key codes associated with devices.

These changes ensure that the API continues to function correctly with the updated command structure.