### PR TITLE
Remove Unnecessary Code and Clean Up CLI for Hubitat Lock Manager

### DIFF
--- a/hubitat_lock_manager/cli.py
+++ b/hubitat_lock_manager/cli.py
@@ -20,8 +20,6 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-        result = smart_lock_controller.list_devices()
-        return jsonify(dataclasses.asdict(result)), 200
 
 def jsonify_result(result):
     return json.dumps(dataclasses.asdict(result))


### PR DESCRIPTION
This PR simplifies the Hubitat Lock Manager CLI by removing unnecessary and misplaced code that was incorrectly placed within the `parse_args()` function. 

### Key Changes:
1. **Removal of Redundant Code**:
   - Removed two lines of misplaced code within the `parse_args()` function that were incorrectly handling the `list_devices` action and returning a JSON result. This code was not relevant to argument parsing and caused confusion in the logic.

2. **Retained JSON Formatting**:
   - The helper function `jsonify_result(result)` for formatting results as JSON remains intact to ensure that all results are properly formatted when required.

This cleanup improves the readability and correctness of the CLI, ensuring that each function is performing only its intended purpose.