### PR TITLE
Add Dynamic Go Installation in Dockerfile with Build Argument Support

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,11 +1,21 @@
 # Define build argument for the base image tag
 ARG TAG=latest
+# Define build argument for the Go version with a default value of 1.20.0
+ARG GO_VERSION=1.20.0
 
 # Extend from the dynamically tagged base Dockerfile
 FROM syncsoftco/hubitat-lock-manager:${TAG}
 
-# Install golang and any other necessary dependencies
-RUN apt-get update && apt-get install -y golang
+# Install Go based on the dynamically provided GO_VERSION
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm go${GO_VERSION}.linux-amd64.tar.gz
+
+# Add Go to the PATH
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
- Updated `Dockerfile.api` to support dynamic Go version installation via a new `GO_VERSION` build argument (default is set to `1.20.0`).
- Removed static installation of Go via `apt-get` and replaced it with downloading Go from the official source based on the provided version.
- Added Go binary to the PATH to ensure proper functionality within the container.
- Improved overall flexibility by allowing dynamic versioning for both the base image and Go during the build process.
- Extended the base image to pull from `syncsoftco/hubitat-lock-manager:${TAG}` as before.