### PR TITLE
Update Go version in Dockerfile.api to 1.20.10

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,7 @@
 # Define build argument for the base image tag
 ARG TAG=latest
 # Define build argument for the Go version with a default value of 1.20.0
-ARG GO_VERSION=1.20.0
+ARG GO_VERSION=1.20.10
 
 # Extend from the dynamically tagged base Dockerfile
 FROM syncsoftco/hubitat-lock-manager:${TAG}


### PR DESCRIPTION
This pull request updates the Go version used in the `Dockerfile.api` from `1.20.0` to `1.20.10`. The change is reflected in the `GO_VERSION` build argument. This ensures the project benefits from the latest bug fixes, improvements, and security patches in the Go runtime.

No other changes have been made in this PR.