### PR TITLE
Upgrade Go Version to 1.20 in GitHub Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,11 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.19'
-
-    - name: Install Go dependencies
-      run: |
-        go mod tidy
+        go-version: '1.20'
 
     - name: Run Go tests
       run: go test ./...


### PR DESCRIPTION
This PR upgrades the Go version from 1.19 to 1.20 in the GitHub Actions workflow (`.github/workflows/test.yaml`). The `go mod tidy` step has been removed as it is no longer necessary for this workflow.

### Changes:
- Updated Go version to 1.20.
- Removed the `go mod tidy` step to streamline the testing process.

This update ensures compatibility with Go 1.20 features and improvements, while also simplifying the workflow.