### PR TITLE
Update ChromeDriver Installation to Match Chrome Version in Dockerfile

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -17,8 +17,11 @@ RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add
     apt-get update && \
     apt-get install -y google-chrome-stable --no-install-recommends
 
-# Install the latest ChromeDriver from a known stable version
-RUN wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip" && \
+# Fetch the Chrome version and install the corresponding ChromeDriver
+RUN CHROME_VERSION=$(google-chrome --version | grep -oP '\d+\.\d+\.\d+') && \
+    echo "Chrome version: $CHROME_VERSION" && \
+    CHROME_DRIVER_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION) && \
+    wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip" && \
     unzip /tmp/chromedriver.zip -d /usr/local/bin/ && \
     rm /tmp/chromedriver.zip
 


### PR DESCRIPTION
This update modifies the `Dockerfile.api` to ensure the correct version of ChromeDriver is installed based on the version of Google Chrome in the container. The change replaces the previous approach of installing the latest ChromeDriver with a more stable and reliable method that:

- Fetches the installed Chrome version using `google-chrome --version`.
- Uses this version to query the corresponding ChromeDriver version from the ChromeDriver storage.
- Downloads and installs the correct version of ChromeDriver, ensuring compatibility with the installed Chrome.

This approach prevents potential mismatches between Chrome and ChromeDriver versions, improving stability and reducing errors during execution.