### PR TITLE
Enhance `create_smart_lock_controller` to Support Custom Command Executors

### DIFF
--- a/hubitat_lock_manager/api.py
+++ b/hubitat_lock_manager/api.py
@@ -10,7 +10,10 @@ COMMAND_EXECUTOR = os.getenv("SELENIUM_EXECUTOR", "")
 HUB_IP = os.getenv("HUB_IP", "192.168.86.37")
 
 app = Flask(__name__)
-smart_lock_controller = controller.create_smart_lock_controller(HUB_IP)
+smart_lock_controller = controller.create_smart_lock_controller(
+    HUB_IP,
+    COMMAND_EXECUTOR,
+)
 
 
 @app.route("/create_key_code", methods=["POST"])

--- a/hubitat_lock_manager/controller.py
+++ b/hubitat_lock_manager/controller.py
@@ -124,9 +124,9 @@ class SmartLockProvider:
         return self.smart_lock_factory.list_smart_locks()
 
 
-def create_smart_lock_controller(hub_ip: str) -> SmartLockController:
+def create_smart_lock_controller(hub_ip: str, command_executor: str) -> SmartLockController:
     # Configure how the code will interact with the Hubitat web interface
-    webdriver_config = smart_lock.WebdriverConfig(hub_ip)
+    webdriver_config = smart_lock.WebdriverConfig(hub_ip, command_executor)
 
     # Create a more specific configuration tailored for using a web browser
     config = smart_lock.create_webdriver_smart_lock_config(webdriver_config)

--- a/hubitat_lock_manager/smart_lock.py
+++ b/hubitat_lock_manager/smart_lock.py
@@ -120,10 +120,11 @@ class SmartLockConfig:
 @dataclass(frozen=True)
 class WebdriverConfig:
     hub_ip: str
+    command_executor: str
     device_name_filter: str = "lock"
 
     @staticmethod
-    def create_driver(command_executor: str = ""):
+    def create_driver():
         options = webdriver.ChromeOptions()    # ChromeDriver can be sensitive to version changes, so we use these arguments to improve stability
         options.add_argument("start-maximized")  # Start the browser maximized
         options.add_argument("enable-automation")  # Enable automation mode
@@ -132,17 +133,16 @@ class WebdriverConfig:
         options.add_argument("--disable-dev-shm-usage")  # Overcome limited resource problems
         options.add_argument("--disable-browser-side-navigation")  # Avoid errors on page load timeout
 
-        if not command_executor:
-            return webdriver.Chrome(
-                service=ChromeService(ChromeDriverManager().install()),
-                options=options,
+        if self.command_executor:
+            return webdriver.Remote(
+                command_executor=command_executor,
+                options=options
             )
 
-        return webdriver.Remote(
-            command_executor=command_executor,
-            options=options
+        return webdriver.Chrome(
+            service=ChromeService(ChromeDriverManager().install()),
+            options=options,
         )
-
 
 def create_generic_z_wave_lock(
     device_id: int,

--- a/hubitat_lock_manager/smart_lock.py
+++ b/hubitat_lock_manager/smart_lock.py
@@ -144,6 +144,7 @@ class WebdriverConfig:
             options=options,
         )
 
+
 def create_generic_z_wave_lock(
     device_id: int,
     position_deleter: PositionDeleter,


### PR DESCRIPTION
This pull request updates the `hubitat_lock_manager` package to support custom command executors for the `SmartLockController`. The changes involve updates to the `api.py`, `controller.py`, and `smart_lock.py` files.

#### Changes Made
1. **`api.py` Updates:**
   - Modified the `create_smart_lock_controller` initialization to include the `COMMAND_EXECUTOR` environment variable. 

2. **`controller.py` Updates:**
   - Updated the `create_smart_lock_controller` function to accept a `command_executor` argument and pass it to `WebdriverConfig`.

3. **`smart_lock.py` Updates:**
   - Modified the `WebdriverConfig` class to include a `command_executor` field.
   - Adjusted the `create_driver` method to conditionally use `webdriver.Remote` if a `command_executor` is provided; otherwise, it uses `webdriver.Chrome`.

#### Impact
- **Flexibility:** This update adds flexibility to the `SmartLockController` by allowing the use of different command executors, which can be crucial for environments where a custom Selenium Grid or remote WebDriver server is used.
- **Compatibility:** By updating how WebDriver is created, this change should improve compatibility and stability, especially in environments where ChromeDriver versions frequently change or in cloud-based test environments.

#### Testing
- Ensure that the `create_smart_lock_controller` function correctly initializes the controller with the provided `command_executor`.
- Test the application with and without the `COMMAND_EXECUTOR` environment variable to verify correct behavior.
- Verify that the `create_driver` method in `smart_lock.py` correctly chooses between `webdriver.Chrome` and `webdriver.Remote` based on the presence of the `command_executor`.